### PR TITLE
CB-5005: Fix plugin id in docs

### DIFF
--- a/docs/accelerometer.md
+++ b/docs/accelerometer.md
@@ -48,7 +48,7 @@ Permissions
 
 #### app/res/xml/config.xml
 
-    <plugin name="Accelerometer" value="org.apache.cordova.AccelListener" />
+    <plugin name="Accelerometer" value="org.apache.cordova.devicemotion.AccelListener" />
 
 ### Bada
 


### PR DESCRIPTION
Make sure the docs match up with what is actually generated in config.xml for Android.
https://issues.apache.org/jira/browse/CB-5005
