### PR TITLE
[CB-6422] Use cordova/exec/proxy instead of platform dupes

### DIFF
--- a/src/firefoxos/accelerometer.js
+++ b/src/firefoxos/accelerometer.js
@@ -38,4 +38,4 @@ var Accelerometer = {
 };
 
 module.exports = Accelerometer;
-require('cordova/firefoxos/commandProxy').add('Accelerometer', Accelerometer);
+require('cordova/exec/proxy').add('Accelerometer', Accelerometer);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CB-6422
[CB-6422] Use cordova/exec/proxy instead of platform dupes
