### PR TITLE
CB-8312 Multiply accelerometer values by -g on Windows

### DIFF
--- a/src/windows/AccelerometerProxy.js
+++ b/src/windows/AccelerometerProxy.js
@@ -26,6 +26,7 @@ var cordova = require('cordova'),
 
 /* This is the actual implementation part that returns the result on Windows 8
 */
+var gConstant = -9.81;
 
 module.exports = {
     onDataChanged:null,
@@ -42,13 +43,13 @@ module.exports = {
             // store our bound function
             this.onDataChanged = function(e) {
                 var a = e.reading;
-                win(new Acceleration(a.accelerationX, a.accelerationY, a.accelerationZ), {keepCallback: true});
+                win(new Acceleration(a.accelerationX * gConstant, a.accelerationY * gConstant, a.accelerationZ * gConstant), {keepCallback: true});
             };
             accel.addEventListener("readingchanged",this.onDataChanged);
 
             setTimeout(function(){
                 var a = accel.getCurrentReading();
-                win(new Acceleration(a.accelerationX, a.accelerationY, a.accelerationZ), {keepCallback: true});
+                win(new Acceleration(a.accelerationX * gConstant, a.accelerationY * gConstant, a.accelerationZ * gConstant), {keepCallback: true});
             },0); // async do later
         }
     },


### PR DESCRIPTION
This is a fix for [CB-8312](https://issues.apache.org/jira/browse/CB-8312)

The story: Windows implementation of device-motion methods returns acceleration, [measured in g's](https://msdn.microsoft.com/en-us/library/windows/apps/windows.devices.sensors.accelerometerreading.accelerationx). To be consistent with current plugin's specs, it is necessary to multiply accelerometer result by G constant (9.81 according to [plugin docs](https://github.com/apache/cordova-plugin-device-motion/blob/master/README.md#acceleration))

Also this PR contains additional commit https://github.com/MSOpenTech/cordova-plugin-device-motion/commit/213cd4b76519428484b78cb4292e0070c23d776d since the PR is based on  __asf/cordova-plugin-device-motion__ repository, which is currently out of sync with https://github.com/apache/cordova-plugin-device-motion. This should correct the sync issue.