### PR TITLE
Returning an OK PluginResult.Status when starting

### DIFF
--- a/src/wp/Accelerometer.cs
+++ b/src/wp/Accelerometer.cs
@@ -147,7 +147,7 @@ namespace WPCordovaClassLib.Cordova.Commands
                 DispatchCommandResult(new PluginResult(PluginResult.Status.IO_EXCEPTION, ErrorFailedToStart));
                 return;
             }
-            PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+            PluginResult result = new PluginResult(PluginResult.Status.OK);
             result.KeepCallback = true;
             DispatchCommandResult(result);
         }


### PR DESCRIPTION
If a status of `No_Result` is returned the plugin will not work when using `navigator.accelerometer.watchAcceleration` on Windows Phone 8