### PR TITLE
CB-8926: The tests module tries to access an undefined global

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -263,7 +263,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         var fail = function (e) {
             console.log("watchAccel fail callback with error code " + e);
             stopAccel();
-            setAccelStatus(Accelerometer.ERROR_MSG[e]);
+            setAccelStatus(e);
         };
 
         // Update acceleration every 1 sec
@@ -306,7 +306,7 @@ exports.defineManualTests = function (contentEl, createActionButton) {
         // Fail callback
         var fail = function (e) {
             console.log("getAccel fail callback with error code " + e);
-            setAccelStatus(Accelerometer.ERROR_MSG[e]);
+            setAccelStatus(e);
         };
 
         // Make call


### PR DESCRIPTION
The tests module tries to access an undefined global 'Accelerometer' on fail callbacks.  This results in another JS error, "ReferenceError: 'Accelerometer' is undefined."  This change passes through the error message instead of attempting to index into the undefined global.