### PR TITLE
CB-9339 Increase the default sensor accuracy

### DIFF
--- a/src/android/AccelListener.java
+++ b/src/android/AccelListener.java
@@ -52,7 +52,7 @@ public class AccelListener extends CordovaPlugin implements SensorEventListener 
     private float x,y,z;                                // most recent acceleration values
     private long timestamp;                         // time of most recent value
     private int status;                                 // status of listener
-    private int accuracy = SensorManager.SENSOR_STATUS_UNRELIABLE;
+    private int accuracy = SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM;
 
     private SensorManager sensorManager;    // Sensor manager
     private Sensor mSensor;                           // Acceleration sensor returned by sensor manager


### PR DESCRIPTION
The current default SENSOR_STATUS_UNRELIABLE is having problems on sensors which fail to report accuracy. 

One such example is Nexus 7 (2013). 

On Android 5.1.1 (api 22) onAccuracyChanged() method is not getting fired for sensor accuracy. As a result the default accuracy is unchanged (SENSOR_STATUS_UNRELIABLE). Since we don't report sensor data if accuracy is lower than medium, we don't report on this hw/sw combination.

Stangely same code on same hw, works on earlier OS (Android 4.3 (api 18)). 

It seems like there's a regression on OS sensor drivers but that's outside of our scope. 

With this change we will now report values for sensors which fail to report any accuracy but some sensor data. In case a sensor fails to report any accuracy and reports bad sensor data, I'm passing the responsibility to the end user to detect and ignore such data (since I'm not able to detect it).

Note that correctly working sensors will get filtered if they report SENSOR_STATUS_UNRELIABLE. This fix will only affect sensors that fail to report any accuracy data at all.