### PR TITLE
CB-11188: cordova-plugin-device-motion-tests are failing in CI

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -24,8 +24,8 @@
 
 exports.defineAutoTests = function () {
     var isWindows = (cordova.platformId === "windows") || (cordova.platformId === "windows8"),
-     // Checking existence of accelerometer for windows platform 
-     // Assumed that accelerometer always exists on other platforms. Extend 
+     // Checking existence of accelerometer for windows platform
+     // Assumed that accelerometer always exists on other platforms. Extend
      // condition to support accelerometer check on other platforms
      isAccelExist = isWindows ? Windows.Devices.Sensors.Accelerometer.getDefault() !== null : true;
 
@@ -178,11 +178,15 @@ exports.defineAutoTests = function () {
             pending();
           }
           var veryRecently = (new Date()).getTime();
+          var ACCEPTABLE_PERCENT_RANGE = 95;
           // Need to check that dates returned are not vastly greater than a recent time stamp.
           // In case the timestamps returned are ridiculously high
           var reasonableTimeLimit = veryRecently + 5000; // 5 seconds from now
           var win = function(a) {
-            expect(a.timestamp).toBeGreaterThan(veryRecently);
+            // Checking if the returned timestamp is atleast 95% of the veryRecently timestamp
+            // If it is greater than very recently (for eg: 125%) it is fine and we do not want
+            // a positive delta comparison in this assert
+            expect((a.timestamp * 100) / veryRecently).toBeGreaterThan(ACCEPTABLE_PERCENT_RANGE);
             expect(a.timestamp).toBeLessThan(reasonableTimeLimit);
             done();
           };


### PR DESCRIPTION
The error is happening in an assert statement where it tries to compare two timestamp values. This kind of comparison is risky as there might be slight variations. For eg: 

1. Expected 1462451458702 to be greater than 1462451458723
2. Expected 1462470496780 to be greater than 1462470496875

In the above examples, you can see the actual value is very close to the expected value. It is 99.9999 percent of the actual value. But, the test is failing due to the strict comparison. So, I have changed the assert to accept the actual value is above 95% of the expected value. 

@omefire @rakatyal  Could you please review and merge this PR?