### PR TITLE
CB-11531 Restart Accelerometer on CyanogenMod 13

### DIFF
--- a/src/android/AccelListener.java
+++ b/src/android/AccelListener.java
@@ -148,6 +148,9 @@ public class AccelListener extends CordovaPlugin implements SensorEventListener 
 
         this.setStatus(AccelListener.STARTING);
 
+        // CB-11531: Reset accuracy to the default level
+        this.accuracy = SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM;
+
         // Get accelerometer from sensor manager
         List<Sensor> list = this.sensorManager.getSensorList(Sensor.TYPE_ACCELEROMETER);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android

### What does this PR do?
Reset sensor `accuracy` after setting it to `SENSOR_STATUS_UNRELIABLE` in `stop` so that check in `onSensorChanged` passes.

### What testing has been done on this change?
Tested on api22, api23 emulators, api22 device.

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

