### PR TITLE
CB-12935: (ios, android) Enable paramedic builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,71 @@
-language: node_js
 sudo: false
-node_js:
-  - "4.2"
+addons:
+  jwt:
+    secure: GbVwXIkFfdi1K89LHl8LNtA1+98aqqBThElVBgX8b6WV0lFFBvnJgpsUKDiVmlIm63za2vt/auEEKMZ+QeIw5qvKy345/If4zGZ/xP6Y6lbd1Rpo817eGfmgah+T5hd3bDFstqe09yjnZRZRwAELBMDQhKrT6Cfdu9664aN8ewc=
+env:
+  global:
+  - SAUCE_USERNAME=snay
+  - TRAVIS_NODE_VERSION="4.2"
+matrix:
+  include:
+  - env: PLATFORM=ios-9.3
+    os: osx
+    osx_image: xcode7.3
+    language: node_js
+    node_js: '4.2'
+  - env: PLATFORM=ios-10.0
+    os: osx
+    osx_image: xcode7.3
+    language: node_js
+    node_js: '4.2'
+  - env: PLATFORM=android-4.4
+    os: linux
+    language: android
+    jdk: oraclejdk8
+    android:
+      components:
+      - tools
+      - tools
+  - env: PLATFORM=android-5.1
+    os: linux
+    language: android
+    jdk: oraclejdk8
+    android:
+      components:
+      - tools
+      - tools
+  - env: PLATFORM=android-6.0
+    os: linux
+    language: android
+    jdk: oraclejdk8
+    android:
+      components:
+      - tools
+      - tools
+  - env: PLATFORM=android-7.0
+    os: linux
+    language: android
+    jdk: oraclejdk8
+    android:
+      components:
+      - tools
+      - tools
+before_install:
+- npm cache clean -f
+- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
+  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
+  install $TRAVIS_NODE_VERSION
+- node --version
+- if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
+- if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
+- if [[ "$PLATFORM" =~ android ]]; then echo y | android update sdk -u --filter android-22,android-23,android-24,android-25;
+  fi
+- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
+  && npm install && popd
+- npm install -g cordova
+install:
+- npm install
+script:
+- npm test
+- node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) --shouldUseSauce
+  --buildName travis-plugin-device-motion-$TRAVIS_JOB_NUMBER


### PR DESCRIPTION
### Platforms affected
iOS, Android

### What does this PR do?
https://issues.apache.org/jira/browse/CB-12935
Enables paramedic builds on Travis CI for device plugin repo.

### What testing has been done on this change?
The Travis CI run which is going to start after the PR is submitted.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
