### PR TITLE
CB-13115 (browser) Fixed getCurrentAcceleration() on Firefox, Safari …

### DIFF
--- a/www/accelerometer.js
+++ b/www/accelerometer.js
@@ -105,6 +105,14 @@ var accelerometer = {
             return;
         }
 
+        if (cordova.platformId === "browser" && !eventTimerId) {
+            // fire devicemotion event once
+            var devicemotionEvent = new Event('devicemotion');
+            window.setTimeout(function() {
+                window.dispatchEvent(devicemotionEvent);
+            }, 200);
+        }
+
         var p;
         var win = function (a) {
             removeListeners(p);


### PR DESCRIPTION
…and Edge

### Platforms affected
Browser

### What does this PR do?
https://issues.apache.org/jira/browse/CB-13115
Makes getCurrentAcceleration() properly fire a `devicemotion` event on some browsers

### What testing has been done on this change?
Manual and automatic testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
