### PR TITLE
chore: Added .npmrc file to assert official NPM registry usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+


### PR DESCRIPTION
This repository is missing it.

This will help prevent unofficial NPM registries from entering the package-lock files if contributors (like myself) has a work/private NPM registry configured as a default.